### PR TITLE
error pages not using absolute paths

### DIFF
--- a/error/403.html
+++ b/error/403.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>insect.christmas &#666;&iuml;&#606;</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="https://insect.christmas/styles.css" />
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -18,7 +18,7 @@
     <table class="centered-container">
         <tr>
             <th>
-                <video autoplay muted loop src="videos/stars.mp4" id="stars" oncanplay="this.play()"></video>
+                <video autoplay muted loop src="https://insect.christmas/videos/stars.mp4" id="stars" oncanplay="this.play()"></video>
             
                 <div class="p1" id="topbar">
                     <h1 style="margin-top: 0; font-size: 42px;"><b id="rainbow">insect.christmas</b> &#666;<b style="color:slateblue;">&iuml;</b>&#606;</h1>
@@ -41,7 +41,7 @@
                 </div>
             </th>
             <th>
-                <a href="https://insect.christmas"><img src="images/ic/icbig.gif" title="izzy X(" style="" height="150px" alt="izzy the bug: X(" id="izzy" data-bs-toggle="tooltip"></a>
+                <a href="https://insect.christmas"><img src="https://insect.christmas/images/ic/icbig.gif" title="izzy X(" style="" height="150px" alt="izzy the bug: X(" id="izzy" data-bs-toggle="tooltip"></a>
             </th>
         </tr>
         <tr>

--- a/error/404.html
+++ b/error/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>insect.christmas &#666;&iuml;&#606;</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="https://insect.christmas/styles.css" />
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -18,7 +18,7 @@
     <table class="centered-container">
         <tr>
             <th>
-                <video autoplay muted loop src="videos/stars.mp4" id="stars" oncanplay="this.play()"></video>
+                <video autoplay muted loop src="https://insect.christmas/videos/stars.mp4" id="stars" oncanplay="this.play()"></video>
             
                 <div class="p1" id="topbar">
                     <h1 style="margin-top: 0; font-size: 42px;"><b id="rainbow">insect.christmas</b> &#666;<b style="color:slateblue;">&iuml;</b>&#606;</h1>
@@ -41,7 +41,7 @@
                 </div>
             </th>
             <th>
-                <a href="https://insect.christmas"><img src="images/ic/icbig.gif" title="izzy X(" style="" height="150px" alt="izzy the bug: X(" id="izzy" data-bs-toggle="tooltip"></a>
+                <a href="https://insect.christmas"><img src="https://insect.christmas/images/ic/icbig.gif" title="izzy X(" style="" height="150px" alt="izzy the bug: X(" id="izzy" data-bs-toggle="tooltip"></a>
             </th>
         </tr>
         <tr>

--- a/error/500.html
+++ b/error/500.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>insect.christmas &#666;&iuml;&#606;</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="https://insect.christmas/styles.css" />
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -18,7 +18,7 @@
     <table class="centered-container">
         <tr>
             <th>
-                <video autoplay muted loop src="videos/stars.mp4" id="stars" oncanplay="this.play()"></video>
+                <video autoplay muted loop src="https://insect.christmas/videos/stars.mp4" id="stars" oncanplay="this.play()"></video>
             
                 <div class="p1" id="topbar">
                     <h1 style="margin-top: 0; font-size: 42px;"><b id="rainbow">insect.christmas</b> &#666;<b style="color:slateblue;">&iuml;</b>&#606;</h1>
@@ -41,7 +41,7 @@
                 </div>
             </th>
             <th>
-                <a href="https://insect.christmas"><img src="images/ic/icbig.gif" title="izzy X(" style="" height="150px" alt="izzy the bug: X(" id="izzy" data-bs-toggle="tooltip"></a>
+                <a href="https://insect.christmas"><img src="https://insect.christmas/images/ic/icbig.gif" title="izzy X(" style="" height="150px" alt="izzy the bug: X(" id="izzy" data-bs-toggle="tooltip"></a>
             </th>
         </tr>
         <tr>


### PR DESCRIPTION
a really minor thing but since all /error pages arent using absolute paths they break when trying to go to them directly (for example /error/404 breaks but any other page that triggers 404 doesnt)