### PR TITLE
fix bluesky link having an incorrect description on external page

### DIFF
--- a/external.html
+++ b/external.html
@@ -72,7 +72,7 @@
                     <hr style="color:chartreuse;">
                     
                     <h2 style="color:slateblue;margin:0;">social media:</h2>
-                    <b><a href="https://bsky.app/profile/insect.christmas">[bluesky]</a></b><br> > official astrid instagram<br>
+                    <b><a href="https://bsky.app/profile/insect.christmas">[bluesky]</a></b><br> > official astrid bluesky<br>
                     <b><a href="https://discord.gg/tV6uBJYqC8">[discord]</a></b><br> > official updates/announcements<br>
                     <b><a href="https://instagram.com/astridztar">[instagram]</a></b><br> > official astrid instagram<br>
                     <b><a href="https://www.reddit.com/r/insectchristmas/">[reddit]</a></b><br>> official astrid subreddit<br>


### PR DESCRIPTION
text under the bluesky link says "official astrid instagram" instead of "official astrid bluesky"